### PR TITLE
#167222763 Get all comments for a particular article with pagination

### DIFF
--- a/src/controllers/CommentController.js
+++ b/src/controllers/CommentController.js
@@ -15,13 +15,11 @@ class CommentController {
   static async addCommentToArticle(req, res) {
     try {
     const articleId = res.locals.articleObject.id;
-    console.log(articleId, 'eeeeeee');
     
     const { userName, bio, imageUrl } = res.locals.articleObject.User;
     const { commentBody } = req.body;
     const userId = req.user;
     
-   
     const commentObject = {
       userId,
       articleId,
@@ -43,6 +41,42 @@ class CommentController {
           bio,
           imageUrl
         }
+      });
+    } catch (error) {
+      return res.status(500).json({
+        status: 500,
+        message: error.message
+      });
+    }
+  }
+  
+  static async getAllArticleComments(req, res) {
+      const { article } = res.locals;
+      const articleId = article.id;
+
+      try {
+      let offset = 0;
+      const { currentPage, limit } = req.query; // page number
+      const defaultLimit = limit || 3; // number of records per page
+      const defaultPage = currentPage || 1;
+
+      const { count, rows: comments } = await Comment.findAndCountAll({
+        where: { articleId },
+        raw: true,
+        attributes: ['id', 'commentBody', 'createdAt'],
+        limit: defaultLimit,
+        offset
+      });
+      
+      const pages = Math.ceil(count / limit) || 1;
+      offset = limit * (defaultPage - 1);
+
+      return res.status(200).json({
+        status: 200,
+        message: 'All comments fetched successfully',
+        article,
+        comments,
+        pages
       });
     } catch (error) {
       return res.status(500).json({

--- a/src/db/models/comment.js
+++ b/src/db/models/comment.js
@@ -27,7 +27,7 @@ const comment = (sequelize, DataTypes) => {
     // associations can be defined here
     Comment.belongsTo(models.User, {
       as: 'userComments',
-      foriegnKey: 'userId',
+      foreignKey: 'userId',
       onDelete: 'CASCADE'
     });
     Comment.belongsTo(models.Article, {

--- a/src/helpers/findItem.js
+++ b/src/helpers/findItem.js
@@ -32,7 +32,6 @@ class FindItem{
       }
       res.locals.article = article
       return next();
-
     } catch (error) {
       return res.status(500).json({
         status: 500,

--- a/src/routes/commentRoute.js
+++ b/src/routes/commentRoute.js
@@ -22,4 +22,11 @@ router.post(
   CommentController.addCommentToArticle,
 );
 
+router.get(
+  '/:slug/comments',
+  verify,
+  FindItem.findArticle,
+  CommentController.getAllArticleComments,
+);
+
 export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -13,6 +13,7 @@ router.use('/api/v1/auth', socialRoute);
 router.use('/api/v1', likeRoute);
 router.use('/api/v1/user', userRoute);
 router.use('/api/v1/', articleRoute);
-router.use('/api/v1/article', commentRoute);
+router.use('/api/v1', userRoute);
+router.use('/api/v1/articles', commentRoute);
 
 export default router;

--- a/test/commentArticle.test.js
+++ b/test/commentArticle.test.js
@@ -9,12 +9,14 @@ const { expect } = chai;
 let token;
 
 describe('CommentArticleController', () => {
-  it('should login user successfully', (done) => {
+  it('should login user successfully', done => {
     const user = {
       email: 'john.doe@andela.com',
       password: 'password',
     };
-    chai.request(app).post('/api/v1/auth/login')
+    chai
+      .request(app)
+      .post('/api/v1/auth/login')
       .send(user)
       .end((err, res) => {
         token = res.body.token;
@@ -26,14 +28,16 @@ describe('CommentArticleController', () => {
         done();
       });
   });
-  it('should create a comment successfully', (done) => {
+  it('should create a comment successfully', done => {
     const comment = {
       commentBody: 'I enjoy reading your articles. Please write more',
     };
-    chai.request(app).post('/api/v1/article/article/comments')
+    chai
+      .request(app)
+      .post('/api/v1/articles/article/comments')
       .send(comment)
       .set('token', token)
-      .end((err, res) => {        
+      .end((err, res) => {
         res.should.have.status(201);
         expect(res.body.message).equal('Comment Added Successfully');
         expect(res.body).to.have.property('createdAt');
@@ -48,11 +52,13 @@ describe('CommentArticleController', () => {
         done();
       });
   });
-  it('should fail to create a comment when the slug is wrong', (done) => {
+  it('should fail to create a comment when the slug is wrong', done => {
     const comment = {
       commentBody: 'I enjoy reading your articles. Please write more',
     };
-    chai.request(app).post('/api/v1/article/articlenb/comments')
+    chai
+      .request(app)
+      .post('/api/v1/articles/articlenb/comments')
       .send(comment)
       .set('token', token)
       .end((err, res) => {
@@ -61,11 +67,13 @@ describe('CommentArticleController', () => {
         done();
       });
   });
-  it('should fail to create a comment when comment body is not provided', (done) => {
+  it('should fail to create a comment when comment body is not provided', done => {
     const comment = {
       commentBody: '',
     };
-    chai.request(app).post('/api/v1/article/article/comments')
+    chai
+      .request(app)
+      .post('/api/v1/articles/article/comments')
       .send(comment)
       .set('token', token)
       .end((err, res) => {
@@ -74,14 +82,17 @@ describe('CommentArticleController', () => {
         expect(res.body.message).to.be.a('string');
         expect(res.body.errors).to.be.a('object');
         expect(res.body.errors.commentBody).to.be.a('array');
-        expect(res.body.errors.commentBody[0]).equal('Comment body is required.');
+        expect(res.body.errors.commentBody[0]).equal(
+          'Comment body is required.'
+        );
         done();
       });
   });
-  it('should fail to create a comment when comment body is not provided', (done) => {
-    const comment = {
-    };
-    chai.request(app).post('/api/v1/article/article/comments')
+  it('should fail to create a comment when comment body is not provided', done => {
+    const comment = {};
+    chai
+      .request(app)
+      .post('/api/v1/articles/article/comments')
       .send(comment)
       .set('token', token)
       .end((err, res) => {
@@ -90,15 +101,19 @@ describe('CommentArticleController', () => {
         expect(res.body.message).to.be.a('string');
         expect(res.body.errors).to.be.a('object');
         expect(res.body.errors.commentBody).to.be.a('array');
-        expect(res.body.errors.commentBody[0]).equal('Comment body is required.');
+        expect(res.body.errors.commentBody[0]).equal(
+          'Comment body is required.'
+        );
         done();
       });
   });
-  it('should fail to create a comment when token is not provided', (done) => {
+  it('should fail to create a comment when token is not provided', done => {
     const comment = {
       commentBody: 'This is the body',
     };
-    chai.request(app).post('/api/v1/article/article/comments')
+    chai
+      .request(app)
+      .post('/api/v1/articles/article/comments')
       .send(comment)
       .set('token', '')
       .end((err, res) => {
@@ -109,11 +124,13 @@ describe('CommentArticleController', () => {
         done();
       });
   });
-  it('should fail to create a comment when token is invalid', (done) => {
+  it('should fail to create a comment when token is invalid', done => {
     const comment = {
       commentBody: 'This is the body',
     };
-    chai.request(app).post('/api/v1/article/article/comments')
+    chai
+      .request(app)
+      .post('/api/v1/articles/article/comments')
       .send(comment)
       .set('token', `${token}k`)
       .end((err, res) => {
@@ -121,6 +138,44 @@ describe('CommentArticleController', () => {
         expect(res.body.error).equal('Invalid token provided');
         expect(res.body).to.have.property('status');
         expect(res.body).to.have.property('error');
+        done();
+      });
+  });
+
+  before(' Populate the comment table', async () => {
+    try {
+      const comment = [
+        {
+          commentBody: 'I love reading your article',
+          userId: 1,
+          articleId: 1,
+        },
+      ];
+      await Comment.bulkCreate(comment);
+    } catch (error) {
+      return error.message;
+    }
+  });
+  it('should get all comments for a particular article successfully', done => {
+    chai
+      .request(app)
+      .get('/api/v1/articles/article/comments?page=1&limit=1')
+      .set('token', token)
+      .end((err, res) => {
+        res.should.have.status(200);
+        expect(res.body.message).equal('All comments fetched successfully');
+        expect(res.body).to.have.property('article');
+        expect(res.body).to.have.property('comments');
+        expect(res.body).to.have.property('pages');
+        expect(res.body).to.have.property('status');
+        expect(res.body.article).to.have.property('title');
+        expect(res.body.article).to.have.property('body');
+        expect(res.body.article.body).to.be.a('string');
+        expect(res.body.comments[0]).to.have.property('commentBody');
+        expect(res.body.comments[0]).to.have.property('createdAt');
+        expect(res.body.comments[0]).to.have.property('id');
+        expect(res.body.article).to.be.a('object');
+        expect(res.body.comments).to.be.a('array');
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
Get a specific article with all the comments

#### Description of Task to be completed?
- Get all comments under a specific article
- Paginate the comments
- Create the route
- Only a verified user can see article comments

#### How should this be manually tested?
- When you hit this route `/api/v1/article/:slug/comments?page=2&limit=5` with a `GET` method,
you should be able to see all comments under the specified article.

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- [#167222763](https://www.pivotaltracker.com/story/show/167222763)

#### Screenshots (if appropriate)

<img width="1129" alt="Screenshot 2019-07-12 at 10 48 35 AM" src="https://user-images.githubusercontent.com/23107014/61119402-a3b15880-a492-11e9-9ca5-2cd53d3273e4.png">

#### Questions:
N/A