### PR TITLE
#166841036 Comments should be able to track edit history

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "babel src -d lib",
     "pretest": "npm run undo:migrate && npm run migrate && npm run seed",
-    "test": "NODE_ENV=test mocha --timeout 50000 --require @babel/register --exit",
+    "test": "NODE_ENV=test nyc mocha --timeout 50000 --require @babel/register --exit",
     "generate-lcov": "nyc report --reporter=text-lcov > lcov.info",
     "coveralls-coverage": "coveralls < lcov.info",
     "coverage": "nyc npm test && npm run generate-lcov && npm run coveralls-coverage",
@@ -18,6 +18,11 @@
     "migrate": "sequelize db:migrate",
     "undo:migrate": "sequelize db:migrate:undo:all",
     "seed": "sequelize db:seed:all"
+  },"nyc": {
+    "exclude": [
+      "src/helpers/mail/*.js",
+      "src/server.js"
+    ]
   },
   "author": "Andela Simulations Programme",
   "license": "MIT",
@@ -46,6 +51,7 @@
     "method-override": "^2.3.10",
     "methods": "^1.1.2",
     "mocha": "^6.1.4",
+    "moment": "^2.24.0",
     "mongoose": "^5.2.2",
     "mongoose-unique-validator": "^2.0.1",
     "multer": "^1.4.1",

--- a/src/db/migrations/20190716060554-create-report.js
+++ b/src/db/migrations/20190716060554-create-report.js
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = {
     up: (queryInterface, Sequelize) => {
       return queryInterface.createTable('Reports', {

--- a/src/db/migrations/20190716062433-create-user-report.js
+++ b/src/db/migrations/20190716062433-create-user-report.js
@@ -1,43 +1,44 @@
+'use strict';
 module.exports = {
-    up: (queryInterface, Sequelize) => {
-      return queryInterface.createTable('UserReports', {
-        id: {
-          allowNull: false,
-          autoIncrement: true,
-          primaryKey: true,
-          type: Sequelize.INTEGER
-        },
-        reporterId: {
-          type: Sequelize.INTEGER,
-          onUpdate: 'CASCADE',
-          onDelete: 'CASCADE',
-          references: {
-            model: 'Users',
-            key: 'id',
-            as: 'reporterId'
-          }
-        },
-        reportId: {
-          type: Sequelize.INTEGER,
-          onUpdate: 'CASCADE',
-          onDelete: 'CASCADE',
-          references: {
-            model: 'Reports',
-            key: 'id',
-            as: 'reportId'
-          }
-        },
-        createdAt: {
-          allowNull: false,
-          type: Sequelize.DATE
-        },
-        updatedAt: {
-          allowNull: false,
-          type: Sequelize.DATE
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('UserReports', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      reporterId: {
+        type: Sequelize.INTEGER,
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+        references: {
+          model: 'Users',
+          key: 'id',
+          as: 'reporterId'
         }
-      });
-    },
-    down: (queryInterface, Sequelize) => {
-      return queryInterface.dropTable('UserReports');
-    }
-  };
+      },
+      reportId: {
+        type: Sequelize.INTEGER,
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+        references: {
+          model: 'Reports',
+          key: 'id',
+          as: 'reportId'
+        }
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('UserReports');
+  }
+};

--- a/src/db/migrations/20190716203009-create-comment-history.js
+++ b/src/db/migrations/20190716203009-create-comment-history.js
@@ -26,7 +26,7 @@ module.exports = {
           },
         },
         commentBody: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           required: true,
         },
         createdAt: {

--- a/src/db/migrations/20190717221306-create-notification.js
+++ b/src/db/migrations/20190717221306-create-notification.js
@@ -1,18 +1,12 @@
 'use strict';
 module.exports = {
   up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('highlightComments', {
+    return queryInterface.createTable('notifications', {
       id: {
         allowNull: false,
         autoIncrement: true,
         primaryKey: true,
         type: Sequelize.INTEGER
-      },
-      highlightedWord: {
-        type: Sequelize.STRING
-      },
-      comment: {
-        type: Sequelize.STRING
       },
       userId: {
         type: Sequelize.INTEGER,
@@ -23,26 +17,26 @@ module.exports = {
           as: 'userId'
         }
       },
-      articleId: {
-        type: Sequelize.INTEGER,
-        onDelete: 'CASCADE',
-        references: {
-          model: 'Articles',
-          key: 'id',
-          as: 'articleId'
-        }
+      message: {
+        type: Sequelize.STRING
+      },
+      isRead: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false
       },
       createdAt: {
         allowNull: false,
-        type: Sequelize.DATE
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
       updatedAt: {
         allowNull: false,
-        type: Sequelize.DATE
-      }
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
     });
   },
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('highlightComments');
+    return queryInterface.dropTable('notifications');
   }
 };

--- a/src/db/migrations/30181008085213-create-commentLike.js
+++ b/src/db/migrations/30181008085213-create-commentLike.js
@@ -1,42 +1,41 @@
 module.exports = {
-    up: (queryInterface, Sequelize) => queryInterface.createTable('CommentLikes', {
-      id: {
-        allowNull: false,
-        autoIncrement: true,
-        primaryKey: true,
-        type: Sequelize.INTEGER
-      },
-      userId: {
-        type: Sequelize.INTEGER,
-        required: true,
-        onUpdate: 'CASCADE',
-        onDelete: 'CASCADE',
-        references: {
-          model: 'Users',
-          key: 'id',
-          as: 'userId'
-        }
-      },
-      commentId: {
-        type: Sequelize.INTEGER,
-        required: true,
-        onUpdate: 'CASCADE',
-        onDelete: 'CASCADE',
-        references: {
-          model: 'Comments',
-          key: 'id',
-          as: 'commentId'
-        }
-      },
-      createdAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      },
-      updatedAt: {
-        allowNull: false,
-        type: Sequelize.DATE
+  up: (queryInterface, Sequelize) => queryInterface.createTable('CommentLikes', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    userId: {
+      type: Sequelize.INTEGER,
+      required: true,
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'userId'
       }
-    }),
-    down: queryInterface => queryInterface.dropTable('CommentLikes'),
-  };
-  
+    },
+    commentId: {
+      type: Sequelize.INTEGER,
+      required: true,
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Comments',
+        key: 'id',
+        as: 'commentId'
+      }
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('CommentLikes'),
+};

--- a/src/db/models/article.js
+++ b/src/db/models/article.js
@@ -50,6 +50,11 @@ module.exports = (sequelize, DataTypes) => {
       onDelete: 'CASCADE',
       onUpdate: 'CASCADE',
     });
+    Article.hasMany(models.highlightComment, {
+      foreignKey: 'articleId',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    });
     Article.hasMany(models.Bookmark, {
       foreignKey: 'articleId',
       onDelete: 'CASCADE',

--- a/src/db/models/comment.js
+++ b/src/db/models/comment.js
@@ -1,7 +1,7 @@
 const comment = (sequelize, DataTypes) => {
   const Comment = sequelize.define('Comment', {
     commentBody: {
-      type: DataTypes.STRING
+      type: DataTypes.TEXT
     },
     userId: {
       type: DataTypes.INTEGER,
@@ -35,6 +35,10 @@ const comment = (sequelize, DataTypes) => {
       as: 'article',
       onDelete: 'CASCADE',
       onUpdate: 'CASCADE'
+    });
+    Comment.hasMany(models.CommentHistory, {
+      foreignKey: 'commentId',
+      as: 'CommentsHistory'
     });
   };
   return Comment;

--- a/src/db/models/commentHistory.js
+++ b/src/db/models/commentHistory.js
@@ -9,7 +9,7 @@ module.exports = (sequelize, DataTypes) => {
         required: true,
       },
       commentBody: {
-        type: DataTypes.STRING,
+        type: DataTypes.TEXT,
         required: true,
       },
     }, {});

--- a/src/db/models/commentLike.js
+++ b/src/db/models/commentLike.js
@@ -1,25 +1,25 @@
 module.exports = (sequelize, DataTypes) => {
-    const CommentLike = sequelize.define('CommentLike', {
-      userId: {
-        type: DataTypes.INTEGER,
-        required: true,
-      },
-      commentId: {
-        type: DataTypes.INTEGER,
-        required: true,
-      }
-    }, {});
-    CommentLike.associate = (models) => {
-        CommentLike.belongsTo(models.Comment, {
-        foreignKey: 'commentId',
-        onDelete: 'CASCADE',
-        onUpdate: 'CASCADE'
-      });
-      CommentLike.belongsTo(models.User, {
-        foreignKey: 'userId',
-        onDelete: 'CASCADE',
-        onUpdate: 'CASCADE'
-      });
-    };
-    return CommentLike;
+  const CommentLike = sequelize.define('CommentLike', {
+    userId: {
+      type: DataTypes.INTEGER,
+      required: true,
+    },
+    commentId: {
+      type: DataTypes.INTEGER,
+      required: true,
+    }
+  }, {});
+  CommentLike.associate = (models) => {
+      CommentLike.belongsTo(models.Comment, {
+      foreignKey: 'commentId',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    });
+    CommentLike.belongsTo(models.User, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    });
   };
+  return CommentLike;
+};

--- a/src/db/models/highlightcomment.js
+++ b/src/db/models/highlightcomment.js
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = (sequelize, DataTypes) => {
     const highlightComment = sequelize.define('highlightComment', {
       highlightedWord: {

--- a/src/db/models/notification.js
+++ b/src/db/models/notification.js
@@ -1,0 +1,17 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const notification = sequelize.define('notification', {
+    userId: DataTypes.INTEGER,
+    message: DataTypes.STRING,
+    isRead: DataTypes.BOOLEAN,
+  }, {});
+  notification.associate = (models) => {
+    // associations can be defined here
+    notification.belongsTo(models.User, {
+      as: 'userNotification',
+      foreignKey: 'id',
+      onDelete: 'CASCADE'
+    });
+  };
+  return notification;
+};

--- a/src/db/models/userreport.js
+++ b/src/db/models/userreport.js
@@ -1,17 +1,17 @@
 module.exports = (sequelize, DataTypes) => {
-    const UserReport = sequelize.define('UserReport', {
-    }, {});
-    UserReport.associate = function(models) {
-      UserReport.belongsTo(models.User, {
-        foreignKey: 'reporterId',
-        onDelete: 'CASCADE',
-        onUpdate: 'CASCADE'
-      });
-      UserReport.belongsTo(models.Report, {
-        foreignKey: 'reportId',
-        onDelete: 'CASCADE',
-        onUpdate: 'CASCADE'
-      });
-    };
-    return UserReport;
+  const UserReport = sequelize.define('UserReport', {
+  }, {});
+  UserReport.associate = function(models) {
+    UserReport.belongsTo(models.User, {
+      foreignKey: 'reporterId',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    });
+    UserReport.belongsTo(models.Report, {
+      foreignKey: 'reportId',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    });
   };
+  return UserReport;
+};

--- a/src/helpers/findItem.js
+++ b/src/helpers/findItem.js
@@ -150,8 +150,8 @@ class FindItem {
     return next();
   }
 
-  /**
-   *@description This function checks if a comment exist
+/**
+   *@description This function checks if a comment exists
    * @param {object} req
    * @param {object} res
    * @param {function} next
@@ -162,7 +162,7 @@ class FindItem {
     const { id } = req.params;
       const comment = await Comment.findOne({
         where: { id },
-        raw: true,       
+        attributes: ['id', 'commentBody', 'createdAt', 'updatedAt', 'articleId'],     
       });
 
       if (!comment) {

--- a/src/routes/commentRoute.js
+++ b/src/routes/commentRoute.js
@@ -1,6 +1,6 @@
 import express from 'express';
 
-// middelwares
+// middelware
 import CommentController from '../controllers/CommentController';
 import verify from '../helpers/verifyToken';
 import CommentValidation from '../middleware/CommentValidation';
@@ -37,5 +37,25 @@ router.post(
   findItem.findComment,
   CommentController.likeComment,
   );
+router.get(
+  '/comments/:id',
+  verify,
+  findItem.findComment,
+  CommentController.getSingleComment,
+);
+
+router.patch(
+  '/comments/:id',
+  verify,
+  findItem.findComment,
+  CommentController.updateComment,
+);
+
+router.get(
+  '/comments/:id/history',
+  verify,
+  findItem.findComment,
+  CommentController.getCommentHistory,
+);
 
 export default router;

--- a/test/commentArticle.test.js
+++ b/test/commentArticle.test.js
@@ -249,4 +249,66 @@ describe('CommentArticleController', () => {
         done();
       });
   });
+
+  it('should fetch a specific comment', (done) => {
+    chai.request(app).get('/api/v1/articles/comments/1')
+      .set('token', testToken)
+      .end((err, res) => {
+        res.should.have.status(200);
+        expect(res.body.data[0]).to.have.property('articleId');
+        expect(res.body.data[0]).to.have.property('comment');
+        done();
+      });
+  });
+
+  it('should indicate that a comment does not exist', (done) => {
+    chai.request(app).get('/api/v1/articles/comments/100')
+      .set('token', testToken)
+      .end((err, res) => {
+        res.should.have.status(404);
+        expect(res.body.message).to.equal('Comment not found');
+        done();
+      });
+  });
+
+  it('should return an empty edit history of a comment', (done) => {
+    chai.request(app).get('/api/v1/articles/comments/1/history')
+      .set('token', testToken)
+      .end((err, res) => {
+        res.should.have.status(200);
+        expect(res.body.message).to.equal('This comment has not been edited');
+        expect(res.body.data[0]).to.have.property('comment');
+        expect(res.body.data[0]).to.have.property('articleId');
+        expect(res.body.data[0]).to.have.property('editHistory');
+        expect(res.body.data[0]).to.have.property('updatedAt');
+        expect(res.body.data[0].editHistory.length).to.equal(0);
+        done();
+      });
+  });
+
+  it('should update a comment', (done) => {
+    chai.request(app).patch('/api/v1/articles/comments/1')
+    .send({commentBody: 'Hello! I am the edited comment'})
+      .set('token', testToken)
+      .end((err, res) => {
+        res.should.have.status(200);
+        expect(res.body.data[0]).to.have.property('articleId');
+        expect(res.body.data[0].comment.commentBody).to.equal('Hello! I am the edited comment');
+        expect(res.body.message).to.equal('Comment updated successfully');
+        done();
+      });
+  });
+
+  it('should fetch the edit history of a comment', (done) => {
+    chai.request(app).get('/api/v1/articles/comments/1/history')
+      .set('token', testToken)
+      .end((err, res) => {
+        res.should.have.status(200);
+        expect(res.body.data[0]).to.have.property('comment');
+        expect(res.body.data[0]).to.have.property('articleId');
+        expect(res.body.data[0]).to.have.property('editHistory');
+        expect(res.body.data[0]).to.have.property('updatedAt');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
- Enables the edit history of a comment to be tracked

#### Description of Task to be completed?
- Create a PATCH API endpoint for updating a comment
- Create a route that makes an API GET request to get the edit history of a particular comment

#### How should this be manually tested?
- After running your server, make an API GET request to the following address: `localhost:3000/api/v1/articles/<article-slug>/comments/<comment-id>/history`
- The edit history of the specified comment will be returned 

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- 166841036
- https://www.pivotaltracker.com/story/show/166841036

#### Screenshots (if appropriate)
- 
<img width="1032" alt="Screenshot 2019-07-17 at 1 51 26 AM" src="https://user-images.githubusercontent.com/14955940/61339688-d2cf1d80-a836-11e9-81bd-9feab4627227.png">


#### Questions:
- N/A
