### PR TITLE
#168054328 Get User Profile By ID Instead Of Username

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "babel src -d lib",
     "pretest": "npm run undo:migrate && npm run migrate && npm run seed",
-    "test": "NODE_ENV=test nyc mocha --timeout 50000 --require @babel/register --exit",
+    "test": "NODE_ENV=test nyc mocha --timeout 100000 --require @babel/register --exit",
     "tes": "NODE_ENV=test nyc mocha --timeout 50000 --require @babel/register ./test/userValidator.test.js --exit",
     "generate-lcov": "nyc report --reporter=text-lcov > lcov.info",
     "coveralls-coverage": "coveralls < lcov.info",

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -16,13 +16,13 @@ class UserController {
    * @memberof UserController
    */
   static async getUserProfile(req, res) {
-    const { userName } = req.params;
+    const { userId } = req.params;
 
     try {
       const userData = await User.findOne({
         attributes: ['firstName', 'lastName', 'userName',
           'email', 'bio', 'imageUrl'],
-        where: { userName },
+        where: { id: userId },
       });
 
       if (!userData) {

--- a/src/routes/userRoute.js
+++ b/src/routes/userRoute.js
@@ -13,7 +13,7 @@ const router = express.Router();
 const { superAdmin } = roles;
 const { idParamValidator, roleValidator } = userValidator;
 
-router.get('/profiles/:userName',
+router.get('/profiles/:userId',
   UserController.getUserProfile);
 
 router.get('/profiles/',

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -131,7 +131,7 @@ describe('UserController', () => {
   });
 
   it('should enable user view another user\'s profile', (done) => {
-    chai.request(app).get('/api/v1/user/profiles/JohnDoe')
+    chai.request(app).get('/api/v1/user/profiles/1')
       .set('token', testToken)
       .end((err, res) => {
         res.should.have.status(200);
@@ -143,8 +143,8 @@ describe('UserController', () => {
       });
   });
 
-  it('should enable user view another user\'s profile', (done) => {
-    chai.request(app).get('/api/v1/user/profiles/JohnDoes')
+  it('should indicate that a user does not exist', (done) => {
+    chai.request(app).get('/api/v1/user/profiles/1000')
       .set('token', testToken)
       .end((err, res) => {
         res.should.have.status(404);


### PR DESCRIPTION
#### What does this PR do?
- Gets user profile by id instead of username

#### Description of Task to be completed?
- Change `userName` to `id` in `route` and `controller`

#### How should this be manually tested?
- Go to the following route using Postman or a browser: `localhost:4000/api/v1/user/profiles/<user-id>`

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- [168054328](https://www.pivotaltracker.com/story/show/168054328)

#### Screenshots (if appropriate)
- N/A

#### Questions:
- N/A
